### PR TITLE
Update call-web-api.md

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -155,7 +155,7 @@ private class TodoItem
       }
 
       private async Task SaveItem() =>
-          await Http.PutAsJsonAsync($"api/TodoItems/{editItem.Id}, editItem);
+          await Http.PutAsJsonAsync("api/TodoItems/" + editItem.Id, editItem);
   }
   ```
   


### PR DESCRIPTION
Fixed a syntactic misprint in the sample code (see line 158). Please check and accept this correction if it's useful:
Before
await Http.PutAsJsonAsync($"api/TodoItems/{editItem.Id}, editItem);
After
await Http.PutAsJsonAsync("api/TodoItems/" + editItem.Id, editItem);